### PR TITLE
Fix incorrect path of TypeErasure

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ For the best free guide for Swift coding use [CS193p](https://cs193p.sites.stanf
 [Create a SwiftUI Tip Calculator](https://github.com/stevencurtis/SwiftCoding/tree/master/SwiftUI/TipSwiftUI)<br>
 
 ### Challenging
-[TypeErasure](https://github.com/stevencurtis/SwiftCoding/tree/master/MVVMDependencyInjection)<br>
+[TypeErasure](https://github.com/stevencurtis/SwiftCoding/tree/master/TypeErasure)<br>
 [TwoWayBinding](https://github.com/stevencurtis/SwiftCoding/tree/master/TwoWayBinding)<br>
 [Track My Movement: A RxSwift Project](https://github.com/stevencurtis/SwiftCoding/tree/master/TrackMyMovement)<br>
 [Secure iOS Apps Through App Pinning](https://github.com/stevencurtis/SwiftCoding/tree/master/SecureiOSAppsthroughAppPinning)<br>


### PR DESCRIPTION
@stevencurtis Discovered this great repo in Github trending channel, thanks for articles collecting!

I found an incorrect link in the README file for TypeErasure section in `Challenging` section and fixed it. Hoping this is meaningful to the repo.